### PR TITLE
SW-281365: Fix dhcpcd interface leak on link overflow

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -1144,9 +1144,17 @@ dhcpcd_checkcarrier(void *arg)
 
 	ifp = if_find(ifp0->ctx->ifaces, ifp0->name);
 	if (ifp == NULL || ifp->carrier == ifp0->carrier)
-		return;
+		goto out;
 
 	dhcpcd_handlecarrier(ifp, ifp0->carrier, ifp0->flags);
+out:
+	/*
+	 * SW-281365: ifp0 is a throw-away interface discovered during route
+	 * socket overflow recovery and is owned by us (the caller removed it
+	 * from the discovered list expecting us to free it). It must be freed
+	 * on every path, otherwise each overflow leaks one struct interface
+	 * per already-known interface, growing dhcpcd RSS without bound.
+	 */
 	if_free(ifp0);
 }
 


### PR DESCRIPTION
Route socket overflow recovery discovers a throw-away interface for every known interface and hands it to dhcpcd_checkcarrier to free. That function only freed it when the carrier changed, so the common no-change path leaked one struct interface per known interface on every overflow, growing RSS without bound. Free it on every path.